### PR TITLE
Make endpoint `/near` respond in JSON

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -678,6 +678,7 @@ dependencies = [
  "openssl",
  "rocket",
  "rocket_contrib",
+ "serde",
 ]
 
 [[package]]
@@ -1347,6 +1348,20 @@ name = "serde"
 version = "1.0.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92d5161132722baa40d802cc70b15262b98258453e85e5d1d365c757c73869ae"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.123"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9391c295d64fc0abb2c556bad848f33cb8296276b1ad2677d1ae1ace4f258f31"
+dependencies = [
+ "proc-macro2 1.0.24",
+ "quote 1.0.9",
+ "syn 1.0.60",
+]
 
 [[package]]
 name = "serde_json"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,12 @@ rocket = "0.4.7"
 diesel = { version = "1.4.5", features = ["postgres"] }
 diesel_geometry = { version = "1.4.0", features = ["postgres"] }
 nanoid = "0.3.0"
+serde = { version = "1", features = ["derive"] }
 
 [dependencies.rocket_contrib]
 version = "0.4.7"
 default-features = false
-features = ["serve", "tera_templates", "diesel_postgres_pool"]
+features = ["serve", "json", "tera_templates", "diesel_postgres_pool"]
 
 [[bin]]
 name = "server"

--- a/src/models.rs
+++ b/src/models.rs
@@ -2,6 +2,10 @@ use std::fmt;
 
 use super::schema::drops;
 use diesel_geometry::pg::data_types::*;
+use serde::{
+    ser::{SerializeStruct, Serializer},
+    Serialize,
+};
 
 #[derive(Clone, Queryable)]
 pub struct MemeDrop {
@@ -20,6 +24,12 @@ pub struct NewMemeDrop {
     pub content: String,
 }
 
+#[derive(Serialize)]
+struct Point {
+    lat: f64,
+    long: f64,
+}
+
 impl MemeDrop {
     pub fn empty() -> Self {
         Self {
@@ -34,5 +44,22 @@ impl MemeDrop {
 impl fmt::Debug for MemeDrop {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "ID: {id}\nLocation: ({lat}, {long})\nMimetype: {mimetype}\nContent: {content}", id = self.id, lat = self.location.0, long = self.location.1, mimetype = self.mimetype, content = self.content)
+impl Serialize for MemeDrop {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut s = serializer.serialize_struct("MemeDrop", 4)?;
+        s.serialize_field("id", &self.id)?;
+        s.serialize_field(
+            "location",
+            &Point {
+                lat: self.location.0,
+                long: self.location.1,
+            },
+        )?;
+        s.serialize_field("mimetype", &self.mimetype)?;
+        s.serialize_field("content", &self.content)?;
+        s.end()
     }
 }


### PR DESCRIPTION
Implements `serde::Serialize` for the `MemeDrop` type and changes `/near` endpoint to return JSON.